### PR TITLE
added METH_VARARGS to PyKAdminPrincipal_modify

### DIFF
--- a/src/PyKAdminPrincipalObject.c
+++ b/src/PyKAdminPrincipalObject.c
@@ -954,7 +954,7 @@ static PyMethodDef PyKAdminPrincipal_methods[] = {
     {"randkey",         (PyCFunction)PyKAdminPrincipal_randomize_key,    METH_NOARGS,   kDOCSTRING_RANDKEY},
     {"randomize_key",   (PyCFunction)PyKAdminPrincipal_randomize_key,    METH_NOARGS,   kDOCSTRING_RANDKEY},
 
-    {"modify",           (PyCFunction)PyKAdminPrincipal_modify,            METH_KEYWORDS, kDOCSTRING_MODIFY},
+    {"modify",           (PyCFunction)PyKAdminPrincipal_modify,            METH_VARARGS | METH_KEYWORDS, kDOCSTRING_MODIFY},
 
     {"commit",           (PyCFunction)PyKAdminPrincipal_commit,           METH_NOARGS,   kDOCSTRING_COMMIT},
     {"reload",           (PyCFunction)PyKAdminPrincipal_reload,           METH_NOARGS,   kDOCSTRING_RELOAD},


### PR DESCRIPTION
in order to compile with Python 3.8.2, I had to OR METH_VARARGS with METH_KEYWORD. This seems to work for me, but I'm new to Python and uncertain of whether it's the right fix.

Hopefully, this will be of some help to others.